### PR TITLE
Add a convenient util for starting cljs compilation and repl

### DIFF
--- a/clojurescript-react/env/dev/clj/fig.clj
+++ b/clojurescript-react/env/dev/clj/fig.clj
@@ -1,0 +1,6 @@
+(ns fig
+  (:require [figwheel-sidecar.repl-api :as ra]))
+
+(defn start []
+  (ra/start-figwheel!)
+  (ra/cljs-repl))


### PR DESCRIPTION
# How to use it
Use one of these approaches
#### 1.
- In terminal, start `lein repl`
- Remember nREPL host & port which you can find in the starting message like this
```
nREPL server started on port 62972 on host 127.0.0.1 - nrepl://127.0.0.1:62972
```
- In repl, execute
```clj
(require 'fig)
(fig/start)
```
- Connect from your favorite editor to nREPL from the above host and port

#### 2.
- In terminal, start `lein repl`
- Remember the same nREPL host & port  as the first approach
- Connect from your favorite editor to nREPL from the above host and port
- In repl in your editor, execute
```clj
(require 'fig)
(fig/start)
```

#### 3.
- Start nREPL in your editor
- In repl in your editor, execute
```clj
(require 'fig)
(fig/start)
```
